### PR TITLE
パンくずリストの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem 'active_hash'
 gem 'pry-rails'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
-
+gem "gretel"
 gem 'ancestry'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -413,6 +415,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-rails
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import "./identification.scss";
 @import "./signup.scss";
 @import "./credit_card.scss";
+@import "./breadcrumbs.scss";
 
 .notifications {
   color: #fff;

--- a/app/assets/stylesheets/breadcrumbs.scss
+++ b/app/assets/stylesheets/breadcrumbs.scss
@@ -1,0 +1,25 @@
+.nav{
+  ul{
+    li{
+      .breadcrumbs{
+        font-size: 20px;
+        line-height: 20px;
+        color: #333;
+        a{
+          font-size: 14px;
+          color: #333;
+          padding: 0 5px;
+        }
+        a:hover{
+          color: #aaa;
+          text-decoration: underline;
+        }
+        span{
+          font-size: 14px;
+          font-weight: bold;
+          padding: 0 5px;
+        }
+      }
+    }
+  }
+}

--- a/app/views/credit_card/show.html.haml
+++ b/app/views/credit_card/show.html.haml
@@ -3,14 +3,10 @@
 
   .nav
     %ul
-      %li
-        メルカリ 
-        = fa_icon 'chevron-right'
-      %li.bold
-        マイページ
-        = fa_icon 'chevron-right'
-      %li.bold
-        支払い方法
+      %li.breadcrumbs
+        - breadcrumb :mypage
+        - breadcrumb :card
+        = breadcrumbs separator: " &rsaquo; "
 
   .main.clearfix    
     = render partial: 'mypage/shared/side_column'

--- a/app/views/mypage/card.html.haml
+++ b/app/views/mypage/card.html.haml
@@ -3,14 +3,10 @@
 
   .nav
     %ul
-      %li
-        メルカリ 
-        = fa_icon 'chevron-right'
-      %li.bold
-        マイページ
-        = fa_icon 'chevron-right'
-      %li.bold
-        支払い方法
+      %li.breadcrumbs
+        - breadcrumb :mypage
+        - breadcrumb :card
+        = breadcrumbs separator: " &rsaquo; "
 
   .main.clearfix
     

--- a/app/views/mypage/identification.html.haml
+++ b/app/views/mypage/identification.html.haml
@@ -2,16 +2,13 @@
 .contents
 
   = render partial: 'shared/header'
+
   .nav
     %ul
-      %li
-        メルカリ 
-        = fa_icon 'chevron-right'
-      %li.bold
-        マイページ
-        = fa_icon 'chevron-right'
-      %li.bold
-        支払い方法
+      %li.breadcrumbs
+        - breadcrumb :mypage
+        - breadcrumb :identification
+        = breadcrumbs separator: " &rsaquo; "
 
   .main.clearfix
     

--- a/app/views/mypage/index.html.haml
+++ b/app/views/mypage/index.html.haml
@@ -2,7 +2,12 @@
 .contents
 
   = render partial: 'shared/header'
-  = render partial: 'shared/nav'
+
+  .nav
+    %ul
+      %li.breadcrumbs
+        - breadcrumb :mypage
+        = breadcrumbs separator: " &rsaquo; "
 
   .main.clearfix
     

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -2,7 +2,13 @@
 .contents
 
   = render partial: 'shared/header'
-  = render partial: 'shared/nav'
+
+  .nav
+    %ul
+      %li.breadcrumbs
+        - breadcrumb :mypage
+        - breadcrumb :profile
+        = breadcrumbs separator: " &rsaquo; "
 
   .main.clearfix
     

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -1,7 +1,10 @@
 .nav
   %ul
-    %li
-      メルカリ 
-      = fa_icon 'chevron-right'
-    %li.bold
-      マイページ
+    %li.breadcrumbs
+      - breadcrumb :mypage
+      - breadcrumb :profile
+      = breadcrumbs separator: " &rsaquo; "
+      -# メルカリ 
+      -# = fa_icon 'chevron-right'
+    -# %li.bold
+    -#   マイページ

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,47 @@
+crumb :root do
+  link "メルカリ", root_path
+end
+
+crumb :mypage do
+  link "マイページ", mypage_path
+end
+
+crumb :profile do
+  link "プロフィール", mypage_profile_path
+  parent :mypage
+end
+
+crumb :identification do
+  link "本人情報の登録", mypage_profile_path
+  parent :mypage
+end
+
+crumb :card do
+  link "支払い方法", mypage_profile_path
+  parent :mypage
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
# What
パンくずリストを作成しました。
取り急ぎマイページ分のみ実装しています。カテゴリ等は該当機能が実装され次第、順次対応していきます。

# Why
UI向上のため。

#### キャプチャ添付します。
[![Image from Gyazo](https://i.gyazo.com/ef45da15d79525ff7438e17234e652b4.gif)](https://gyazo.com/ef45da15d79525ff7438e17234e652b4)